### PR TITLE
fix: replace explicit any types in grievance form components

### DIFF
--- a/frontend/app/submit/page.tsx
+++ b/frontend/app/submit/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import type { ChangeEvent, FormEvent } from "react";
 import Input from "@/components/ui/Input";
 import Button from "@/components/ui/Button";
 import Toast from "@/components/ui/Toast";
@@ -20,7 +21,7 @@ export default function SubmitPage() {
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState("");
 
-  const handleChange = (e: any) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
@@ -29,7 +30,7 @@ export default function SubmitPage() {
     setOpen(false);
   };
 
-  const handleSubmit = (e: any) => {
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     if (!form.name || !form.email || !form.category || !form.title || !form.description) {

--- a/frontend/components/ui/Input.tsx
+++ b/frontend/components/ui/Input.tsx
@@ -1,8 +1,10 @@
+import type { ChangeEventHandler } from "react";
+
 type InputProps = {
   label: string;
   name: string;
   value: string;
-  onChange: any;
+  onChange: ChangeEventHandler<HTMLInputElement>;
   placeholder?: string;
 };
 


### PR DESCRIPTION
### Motivation
- Remove unsafe `any` event types in the grievance submission UI to satisfy linting rules and improve type-safety for form handlers.

### Description
- Typed the form change handler as `ChangeEvent<HTMLInputElement | HTMLTextAreaElement>` in `frontend/app/submit/page.tsx`.
- Typed the form submit handler as `FormEvent<HTMLFormElement>` in `frontend/app/submit/page.tsx`.
- Updated the shared `Input` component `onChange` prop to `ChangeEventHandler<HTMLInputElement>` and imported the type in `frontend/components/ui/Input.tsx`.

### Testing
- Ran `cd frontend && npm run lint`, which completed successfully (no ESLint errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63e226f7c8329aa290cbb89b91422)