### PR TITLE
Fix backend import paths so FastAPI app can be imported from repo root

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,7 +1,7 @@
 from passlib.context import CryptContext
 from jose import JWTError, jwt
 from datetime import datetime, timedelta
-from app.config import SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES
+from backend.app.config import SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, String
-from app.database import Base
+from backend.app.database import Base
 
 class User(Base):
     __tablename__ = "users"

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,10 @@
 from fastapi import FastAPI, Depends, HTTPException, Header
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
-from app.database import SessionLocal, engine, Base
-import app.models as models
-import app.schemas as schemas
-import app.auth as auth
+from backend.app.database import SessionLocal, engine, Base
+import backend.app.models as models
+import backend.app.schemas as schemas
+import backend.app.auth as auth
 
 Base.metadata.create_all(bind=engine)
 


### PR DESCRIPTION
### Motivation
- Starting the API with `uvicorn backend.main:app` from the repository root raised `ModuleNotFoundError: No module named 'app'` because internal imports used bare module names instead of package-qualified paths.

### Description
- Updated `backend/main.py` to import `SessionLocal`, `engine`, and `Base` from `backend.app.database` and to import `backend.app.models`, `backend.app.schemas`, and `backend.app.auth` instead of bare `app.*` imports.
- Updated `backend/app/models.py` to import `Base` from `backend.app.database` for correct package resolution.
- Updated `backend/app/auth.py` to import config values from `backend.app.config` to match the package-qualified import strategy.

### Testing
- Ran `python -m py_compile backend/main.py backend/app/*.py` which completed successfully.
- Launched `uvicorn backend.main:app --host 127.0.0.1 --port 8001` which confirmed the original import error was resolved and startup proceeded further, but the server then failed due to a missing environment dependency (`ModuleNotFoundError: No module named 'passlib'`), which is an external dependency issue rather than a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64050c51883299f8b26d5bfc8914f)