### PR TITLE
Admin dashboard: fetch live grievances and add loading/error/empty states

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,47 +1,92 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import StatusBadge from "@/components/ui/StatusBadge";
 
+type Grievance = {
+  id: number;
+  name: string;
+  title: string;
+  status?: string;
+};
+
 export default function AdminDashboard() {
-  const grievances = [
-    { id: 1, name: "Saket", title: "Water issue", status: "Pending" },
-    { id: 2, name: "Rahul", title: "Road damage", status: "Resolved" },
-    { id: 3, name: "Amit", title: "Electricity cut", status: "Urgent" },
-  ];
+  const [grievances, setGrievances] = useState<Grievance[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const fetchGrievances = async () => {
+      try {
+        const apiBase = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+        const response = await fetch(`${apiBase}/grievances`, {
+          signal: controller.signal,
+          cache: "no-store",
+        });
+
+        if (!response.ok) {
+          throw new Error("Failed to load grievances");
+        }
+
+        const data: Grievance[] = await response.json();
+        setGrievances(data);
+      } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") {
+          return;
+        }
+
+        setError("Unable to fetch grievances right now.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchGrievances();
+
+    return () => controller.abort();
+  }, []);
 
   return (
     <div>
-
       <h2 className="text-xl mb-6">Grievances</h2>
 
-      <div className="overflow-x-auto bg-white/5 border border-white/10 rounded-xl">
-        <table className="w-full text-left">
+      {loading && <p className="text-gray-300">Loading grievances...</p>}
 
-          <thead className="bg-white/10">
-            <tr>
-              <th className="p-4">ID</th>
-              <th className="p-4">Name</th>
-              <th className="p-4">Title</th>
-              <th className="p-4">Status</th>
-            </tr>
-          </thead>
+      {!loading && error && <p className="text-red-400">{error}</p>}
 
-          <tbody>
-            {grievances.map((g) => (
-              <tr key={g.id} className="border-t border-white/10 hover:bg-white/5">
-                <td className="p-4">{g.id}</td>
-                <td className="p-4">{g.name}</td>
-                <td className="p-4">{g.title}</td>
-                <td className="p-4">
-                  <StatusBadge status={g.status} />
-                </td>
+      {!loading && !error && grievances.length === 0 && (
+        <p className="text-gray-300">No grievances submitted yet.</p>
+      )}
+
+      {!loading && !error && grievances.length > 0 && (
+        <div className="overflow-x-auto bg-white/5 border border-white/10 rounded-xl">
+          <table className="w-full text-left">
+            <thead className="bg-white/10">
+              <tr>
+                <th className="p-4">ID</th>
+                <th className="p-4">Name</th>
+                <th className="p-4">Title</th>
+                <th className="p-4">Status</th>
               </tr>
-            ))}
-          </tbody>
+            </thead>
 
-        </table>
-      </div>
-
+            <tbody>
+              {grievances.map((g) => (
+                <tr key={g.id} className="border-t border-white/10 hover:bg-white/5">
+                  <td className="p-4">{g.id}</td>
+                  <td className="p-4">{g.name}</td>
+                  <td className="p-4">{g.title}</td>
+                  <td className="p-4">
+                    <StatusBadge status={g.status || "Pending"} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- The admin page previously showed hard-coded demo rows which made the dashboard misleading and unusable with a real backend.
- The change aims to surface real grievance data from the backend so admins see up-to-date information and clear feedback when data is missing or loading.

### Description
- Replaced static demo data with client-side fetching from `
NEXT_PUBLIC_API_URL/grievances` and added a fallback to `http://localhost:8000` if the env var is not set, in `frontend/app/admin/page.tsx`.
- Added `Grievance` TypeScript type, `useState` for `grievances`, `loading`, and `error`, and rendering for loading, error, and empty states.
- Implemented safe request cancellation with `AbortController` and ensured rendering uses a default status of `"Pending"` when a record lacks a `status` field.
- Kept the same table UI but only render it when there are records, improving UX and preventing stale mock data from being displayed.

### Testing
- Ran `cd frontend && npm run lint` and it completed successfully.
- Ran `cd frontend && npm run build` and the production build completed successfully with pages generated and TypeScript checks passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6408c9e7c83298eecadcfe2c43a73)