### PR TITLE
feat: add automatic grievance escalation engine and escalation levels…

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -35,6 +35,7 @@ class Grievance(Base):
     rating = Column(Integer, nullable=True)
     feedback = Column(String, nullable=True)
     reopened_count = Column(Integer, default=0)
+    escalation_level = Column(Integer, default=1)
     created_at = Column(DateTime, default=datetime.utcnow)
 
     # Relationships

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -78,6 +78,7 @@ class GrievanceOut(BaseModel):
     rating: Optional[int] = None
     feedback: Optional[str] = None
     reopened_count: int = 0
+    escalation_level: int = 1
     citizen_count: int = 1
     created_at: datetime
     timeline: List[GrievanceTimelineOut] = []

--- a/backend/main.py
+++ b/backend/main.py
@@ -52,6 +52,89 @@ def get_db():
     finally:
         db.close()
 
+def auto_escalate_grievances(db: Session):
+    from datetime import datetime
+    from backend.app.notifications import NotificationService
+
+    unresolved = db.query(models.Grievance).filter(models.Grievance.status != "Resolved").all()
+    now = datetime.utcnow()
+
+    for g in unresolved:
+        days_elapsed = (now - g.created_at).days
+        new_level = g.escalation_level
+
+        if days_elapsed >= 15:
+            new_level = max(new_level, 3)
+        elif days_elapsed >= 7:
+            new_level = max(new_level, 2)
+        else:
+            new_level = max(new_level, 1)
+
+        if new_level > g.escalation_level:
+            g.escalation_level = new_level
+            
+            level_name = {
+                2: "Level 2 (Department Head)",
+                3: "Level 3 (District Administration)"
+            }.get(new_level, "Unknown")
+
+            # Log to timeline
+            timeline_event = models.GrievanceTimeline(
+                grievance_id=g.id,
+                status="Escalated",
+                remarks=f"Grievance automatically escalated to {level_name} due to inactivity."
+            )
+            db.add(timeline_event)
+
+            # Send notifications
+            owner_email = None
+            owner_phone = None
+            if g.user_id:
+                owner = db.query(models.User).filter(models.User.id == g.user_id).first()
+                if owner:
+                    owner_email = owner.email
+                    owner_phone = owner.phone
+
+            try:
+                # Notify creator
+                target_email = owner_email or g.email
+                if target_email:
+                    NotificationService.send_email(
+                        target_email,
+                        f"Naarad-GRS Escalation: Grievance #{g.id} Escalated",
+                        f"Your Grievance #{g.id} ({g.title}) has been automatically escalated to {level_name} due to inactivity."
+                    )
+                target_phone = owner_phone or g.phone
+                if target_phone:
+                    msg = f"Naarad-GRS: Grievance #{g.id} has been escalated to {level_name}."
+                    NotificationService.send_sms(target_phone, msg)
+                    NotificationService.send_whatsapp(target_phone, msg)
+
+                # Notify subscribers
+                for sub in g.subscriptions:
+                    sub_email = sub.email
+                    sub_phone = sub.phone
+                    if sub.user_id:
+                        sub_user = db.query(models.User).filter(models.User.id == sub.user_id).first()
+                        if sub_user:
+                            sub_email = sub_email or sub_user.email
+                            sub_phone = sub_phone or sub_user.phone
+                    
+                    if sub_email:
+                        NotificationService.send_email(
+                            sub_email,
+                            f"Naarad-GRS Watch Alert: Grievance #{g.id} Escalated",
+                            f"Grievance #{g.id} ({g.title}) you are watching has been automatically escalated to {level_name} due to inactivity."
+                        )
+                    if sub_phone:
+                        msg = f"Naarad-GRS Watch Alert: Grievance #{g.id} has been escalated to {level_name}."
+                        NotificationService.send_sms(sub_phone, msg)
+                        NotificationService.send_whatsapp(sub_phone, msg)
+            except Exception as e:
+                print(f"Failed to dispatch escalation alerts: {e}")
+
+    db.commit()
+
 # REGISTER
 @app.post("/register")
 def register(user: schemas.UserCreate, db: Session = Depends(get_db)):
@@ -217,6 +300,7 @@ def get_grievances(
     admin_user: models.User = Depends(require_role("admin")),
     db: Session = Depends(get_db)
 ):
+    auto_escalate_grievances(db)
     return db.query(models.Grievance).all()
 
 # GET USER GRIEVANCES
@@ -225,6 +309,7 @@ def get_my_grievances(
     current_user: models.User = Depends(get_current_user),
     db: Session = Depends(get_db)
 ):
+    auto_escalate_grievances(db)
     return db.query(models.Grievance).filter(models.Grievance.user_id == current_user.id).all()
 
 # UPDATE GRIEVANCE

--- a/backend/scripts/run_escalation.py
+++ b/backend/scripts/run_escalation.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+# Add workspace root directory to Python path
+workspace_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(workspace_root)
+
+from backend.app.database import SessionLocal
+from backend import main
+
+def main_run():
+    print("Starting automatic Naarad-GRS Escalation Engine...")
+    db = SessionLocal()
+    try:
+        main.auto_escalate_grievances(db)
+        print("Escalation engine run completed successfully.")
+    except Exception as e:
+        print(f"Error executing escalation engine: {e}")
+    finally:
+        db.close()
+
+if __name__ == "__main__":
+    main_run()

--- a/backend/test_api.py
+++ b/backend/test_api.py
@@ -259,6 +259,46 @@ def test_all():
     assert g1.timeline[-1].status == "Reopened"
     assert "Work is incomplete" in g1.timeline[-1].remarks
     print("Reopened timeline entry verified:", g1.timeline[-1].remarks)
+
+    print("\n--- 11. Testing Automatic Escalation Engine ---")
+    # Verify default escalation level is 1
+    assert g2.escalation_level == 1
+
+    # Mock g2's created_at to 8 days ago to trigger Level 2 escalation
+    from datetime import datetime, timedelta
+    g2.created_at = datetime.utcnow() - timedelta(days=8)
+    db.commit()
+
+    main.auto_escalate_grievances(db)
+    db.refresh(g2)
+    print("Escalation level after 8 days:", g2.escalation_level)
+    assert g2.escalation_level == 2
+    # Verify timeline entry
+    assert g2.timeline[-1].status == "Escalated"
+    assert "Level 2 (Department Head)" in g2.timeline[-1].remarks
+
+    # Mock g2's created_at to 16 days ago to trigger Level 3 escalation
+    g2.created_at = datetime.utcnow() - timedelta(days=16)
+    db.commit()
+
+    main.auto_escalate_grievances(db)
+    db.refresh(g2)
+    print("Escalation level after 16 days:", g2.escalation_level)
+    assert g2.escalation_level == 3
+    # Verify timeline entry
+    assert g2.timeline[-1].status == "Escalated"
+    assert "Level 3 (District Administration)" in g2.timeline[-1].remarks
+
+    # Test standalone run_escalation CLI script executes
+    import subprocess
+    cli_res = subprocess.run(
+        [sys.executable, "backend/scripts/run_escalation.py"],
+        capture_output=True,
+        text=True
+    )
+    print("CLI script output:", cli_res.stdout)
+    assert cli_res.returncode == 0
+    assert "completed successfully" in cli_res.stdout
     
     print("\nALL BACKEND TESTS PASSED SUCCESSFULLY!")
 

--- a/frontend/components/GrievanceCard.tsx
+++ b/frontend/components/GrievanceCard.tsx
@@ -24,6 +24,7 @@ type Props = {
     feedback?: string | null;
     reopened_count?: number;
     citizen_count?: number;
+    escalation_level?: number;
     timeline?: TimelineEvent[];
   };
   onUpdate?: () => void;
@@ -143,8 +144,30 @@ export default function GrievanceCard({ grievance, onUpdate }: Props) {
     activeStep = 3; // "In Progress" or similar
   }
 
-  // Get officer details based on category
-  const getOfficerDetails = (cat: string) => {
+  // Get officer details based on category and escalation level
+  const getOfficerDetails = (cat: string, escLevel: number = 1) => {
+    if (escLevel === 3) {
+      return { 
+        name: "Dr. Amit Sharma, IAS", 
+        role: "District Collector & Magistrate, District Administration", 
+        phone: "+91 98234 99001" 
+      };
+    }
+
+    if (escLevel === 2) {
+      switch (cat) {
+        case "Electricity":
+          return { name: "Shri Vinayak Rao", role: "Superintending Engineer, State Electricity Board", phone: "+91 98234 55667" };
+        case "Water":
+          return { name: "Shri Ramesh Deshpande", role: "Chief Engineer, Municipal Water Works", phone: "+91 98234 22334" };
+        case "Road":
+          return { name: "Shri Nitin Gadkari Jr.", role: "Director of Urban Road Infrastructure", phone: "+91 98234 66778" };
+        default:
+          return { name: "Shri Prakash Mehta", role: "Joint Commissioner, Public Grievance Dept", phone: "+91 98234 88990" };
+      }
+    }
+
+    // Default Level 1
     switch (cat) {
       case "Electricity":
         return { name: "Er. Rajesh Patel", role: "Executive Engineer, Power Distribution Dept", phone: "+91 98234 56789" };
@@ -157,7 +180,7 @@ export default function GrievanceCard({ grievance, onUpdate }: Props) {
     }
   };
 
-  const officer = getOfficerDetails(grievance.category);
+  const officer = getOfficerDetails(grievance.category, grievance.escalation_level);
 
   return (
     <div className="border border-border-custom rounded-xl p-6 shadow-lg bg-bg-secondary hover:border-accent-primary transition duration-300 flex flex-col gap-6">
@@ -204,6 +227,22 @@ export default function GrievanceCard({ grievance, onUpdate }: Props) {
           }`}>
             {grievance.priority} Priority
           </span>
+
+          {grievance.status !== "Resolved" && (
+            <span className={`px-2.5 py-0.5 rounded text-xs font-semibold ${
+              grievance.escalation_level === 3
+                ? "bg-red-500/20 text-red-400 border border-red-500/30 animate-pulse-slow"
+                : grievance.escalation_level === 2
+                ? "bg-yellow-500/20 text-yellow-400 border border-yellow-500/30"
+                : "bg-green-500/20 text-green-400 border border-green-500/30"
+            }`}>
+              {grievance.escalation_level === 3
+                ? "🚨 Level 3 - District Admin"
+                : grievance.escalation_level === 2
+                ? "⚠️ Level 2 - Dept Head"
+                : "🟢 Level 1 - Municipal Officer"}
+            </span>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Overview
This PR implements an automatic Escalation Engine inside Naarad-GRS. Grievances that remain unresolved are automatically escalated through three levels of authority based on the elapsed time since they were raised (Day 0, Day 7, and Day 15).

## Key Changes
* **Database Models** (`backend/app/models.py`):
  * Added `escalation_level = Column(Integer, default=1)` to track the active escalation stage.
* **Validation Schema** (`backend/app/schemas.py`):
  * Added `escalation_level: int = 1` to `GrievanceOut` schema.
* **Escalation Logic & Alert Dispatches** (`backend/main.py`):
  * Implemented `auto_escalate_grievances(db)` executing Day 7 (Level 2) and Day 15 (Level 3) escalations.
  * Integrated JIT trigger hooks in admin and citizen list GET endpoints.
* **CLI Trigger Script** (`backend/scripts/run_escalation.py`):
  * Added a standalone execution script suitable for nightly cron jobs to run escalations offline.
* **Frontend Indicators** (`frontend/components/GrievanceCard.tsx`):
  * Displays color-coded, pulsing escalation badges: Level 1 (Local), Level 2 (Dept Head), and Level 3 (District Admin).
  * Dynamically updates the officer contact panel to render escalated authority contact cards based on category and escalation level.

## Verification
* Ran unit tests: `venv\Scripts\python backend/test_api.py` (100% Passed).
* Ran build compile: `npm run build` (Successful compile).